### PR TITLE
Fix CRT upload in diyca_web_main.py

### DIFF
--- a/app_web/diyca_web_main.py
+++ b/app_web/diyca_web_main.py
@@ -376,7 +376,7 @@ def web_request_sign_csr():
     # Download CRT file to user
     return send_file(crt_filepath,
                      mimetype='application/pkix-cert',
-                     attachment_filename=crt_filename,
+                     download_name=crt_filename,
                      as_attachment=True)
 
 #------------ Begin Launched Program ------------------------------------


### PR DESCRIPTION
"attachment_filename" is no longer valid, see https://github.com/pallets/flask/pull/4667